### PR TITLE
Allow setting db directory from env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+/ci
+
 # secrets
 .env
 

--- a/server/server.js
+++ b/server/server.js
@@ -15,7 +15,11 @@ app.use(express.json());
 // Database connection and initialization
 let db;
 (async () => {
-  const dbPath = path.resolve(__dirname, '../subscriptions.db');
+  const path = require('path');
+  // Use an environment variable if set, otherwise fallback to __dirname
+  const baseDir = process.env.DB_DIR || __dirname;
+  const dbPath = path.join(baseDir, '/subscriptions.db');
+  console.log(`Using subscriptions database located at: ${dbPath} due to baseDir: ${baseDir}`);
   db = await open({
     filename: dbPath,
     driver: sqlite3.Database,


### PR DESCRIPTION
This adds allowing setting an environment variable `DB_DIR` for the db storage so it doesn't have to be stored in the app directory.