### PR TITLE
word wrap for name too long

### DIFF
--- a/src/components/SubscriptionList.tsx
+++ b/src/components/SubscriptionList.tsx
@@ -407,7 +407,16 @@ export default function SubscriptionList({
                     style={{ color: sub.color, fontSize: '1.5em' }}
                   />
                   <div>
-                    <p style={{ fontSize: '1.2em', margin: 0, color: '#fff' }}>{sub.name}</p>
+                    <p style={{ 
+                      fontSize: '1.2em', 
+                      margin: 0, 
+                      color: '#fff',
+                      wordWrap: 'break-word',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '200px'
+                    }}>{sub.name}</p>
                     <p style={{ fontSize: '0.8em', margin: 0, color: '#adadad' }}>
                       {formatCurrency(sub.amount, sub.currency)}/{sub.intervalValue} {sub.intervalUnit}
                     </p>


### PR DESCRIPTION
before

<img width="1013" height="125" alt="image" src="https://github.com/user-attachments/assets/7209bac3-6702-48b6-979d-a75d47aaaa71" />

after

<img width="992" height="117" alt="image" src="https://github.com/user-attachments/assets/6c508835-909e-48dd-8cce-4b8e338f4b36" />
