### PR TITLE
fix: resolve timezone offset issue in edit modal date display

### DIFF
--- a/src/components/SubscriptionModal.tsx
+++ b/src/components/SubscriptionModal.tsx
@@ -7,6 +7,7 @@ import getSymbolFromCurrency from 'currency-symbol-map';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import '@/styles/react-datepicker-dark.css';
+import { parseISO } from 'date-fns';
 import { Subscription } from '@/types';
 import { getRandomColor } from '@/lib/utils';
 import styles from './SubscriptionModal.module.css';
@@ -50,10 +51,10 @@ export default function SubscriptionModal({
       setId(selectedSubscription.id || null);
       setName(selectedSubscription.name);
       setAmount(selectedSubscription.amount.toString());
-      setDueDate(selectedSubscription.dueDate 
-        ? new Date(selectedSubscription.dueDate) 
-        : (selectedSubscription.due_date 
-          ? new Date(selectedSubscription.due_date) 
+      setDueDate(selectedSubscription.dueDate
+        ? parseISO(selectedSubscription.dueDate)
+        : (selectedSubscription.due_date
+          ? parseISO(selectedSubscription.due_date)
           : null));
       setIcon(selectedSubscription.icon || '');
       setIconInput(selectedSubscription.icon || '');


### PR DESCRIPTION
## Summary
- Fixes timezone offset bug where dates in the edit modal displayed one day earlier than expected
- Replaced `new Date()` with `parseISO()` from date-fns for proper ISO 8601 date parsing
- All API tests passing (11/11)

## Problem
When editing a subscription, the date would show correctly in the list and calendar but appear one day earlier in the edit modal. For example, a subscription saved on the 15th would show as the 14th when reopened for editing.

## Root Cause
The date string from the database (e.g., "2024-02-15") was being parsed with `new Date()`, which interprets it as UTC midnight. In timezones behind UTC (like EST/UTC-5), this caused the date to shift backward by one day when displayed in the user's local timezone.

## Solution
Used `parseISO()` from the date-fns library (already in use elsewhere in the codebase) which properly handles ISO 8601 date strings without timezone interpretation issues.

## Testing
- ✅ Built and ran podman container successfully
- ✅ All 11 API tests passed
- ✅ Ready for GUI verification

## Files Changed
- `src/components/SubscriptionModal.tsx`: Added parseISO import and replaced Date constructor calls