### PR TITLE
Fix: tag filter causes "Maximum update depth exceeded" crash

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Header from '@/components/Header';
 import SubscriptionList from '@/components/SubscriptionList';
 import SubscriptionModal from '@/components/SubscriptionModal';
@@ -139,6 +139,17 @@ export default function Home() {
       )
     );
   };
+
+  const handleFilteredSubscriptionsChange = useCallback(
+    (nextFilteredSubscriptions: Subscription[]) => {
+      setFilteredSubscriptions(nextFilteredSubscriptions);
+    },
+    []
+  );
+
+  const handleTagFilterChange = useCallback((tags: string[]) => {
+    setSelectedTags(tags);
+  }, []);
 
   const handleDateClick = (date: Date) => {
     setSelectedDate(date);
@@ -342,8 +353,8 @@ export default function Home() {
           onDelete={handleDeleteSubscription}
           onToggleInclude={handleToggleInclude}
           showCurrencySymbol={userConfig.showCurrencySymbol}
-          onFilteredSubscriptionsChange={(filteredSubs) => setFilteredSubscriptions(filteredSubs)}
-          onTagFilterChange={(tags) => setSelectedTags(tags)}
+          onFilteredSubscriptionsChange={handleFilteredSubscriptionsChange}
+          onTagFilterChange={handleTagFilterChange}
         />
         <Totals
           subscriptions={filteredSubscriptions || subscriptions}

--- a/src/components/SubscriptionList.tsx
+++ b/src/components/SubscriptionList.tsx
@@ -242,11 +242,14 @@ export default function SubscriptionList({
   };
 
   // Filter subscriptions by tags
-  const filteredSubscriptions = tagFilters.length > 0
-    ? subscriptions.filter(sub =>
-      sub.tags && sub.tags.some(tag => tagFilters.includes(tag))
-    )
-    : subscriptions;
+  const filteredSubscriptions = useMemo(() =>
+    tagFilters.length > 0
+      ? subscriptions.filter(sub =>
+        sub.tags && sub.tags.some(tag => tagFilters.includes(tag))
+      )
+      : subscriptions,
+    [subscriptions, tagFilters]
+  );
 
   // Notify parent about filtered subscriptions
   useEffect(() => {


### PR DESCRIPTION
A fix for [Crash when filtering by a tag #29](https://github.com/dh1011/subscription-manager/issues/29)


Clicking a tag badge to filter subscriptions triggers an infinite re-render loop because:

filteredSubscriptions is recomputed via .filter() on every render, producing a new array reference

The useEffect that pushes this to the parent fires on every new reference

Parent re-renders with new inline callback props, re-triggering the effect

Fixed by:

Wrapping filteredSubscriptions in useMemo

Stabilizing parent callbacks with useCallback



Changes by Sonnet 4.6 