### PR TITLE
feature: select drop down for icon

### DIFF
--- a/src/components/SubscriptionModal.tsx
+++ b/src/components/SubscriptionModal.tsx
@@ -10,6 +10,10 @@ import '@/styles/react-datepicker-dark.css';
 import { parseISO, startOfDay } from 'date-fns';
 import { Subscription } from '@/types';
 import { getRandomColor } from '@/lib/utils';
+import {
+  MATERIAL_DESIGN_ICON_OPTIONS,
+  MATERIAL_DESIGN_ICON_VALUES
+} from '@/constants/materialDesignIcons';
 import styles from './SubscriptionModal.module.css';
 
 const currencyList = require('currency-symbol-map/map');
@@ -130,7 +134,7 @@ export default function SubscriptionModal({
     onClose();
   };
 
-  const handleIconChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleIconChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setIconInput(e.target.value);
     setIcon(e.target.value.toLowerCase());
   };
@@ -243,14 +247,22 @@ export default function SubscriptionModal({
           <div className={styles.formGroup}>
             <label htmlFor="icon">Icon <span style={{ color: '#ff4444' }}>*</span></label>
             <div className={styles.iconInputContainer}>
-              <input
+              <select
                 id="icon"
-                type="text"
                 value={iconInput}
                 onChange={handleIconChange}
-                placeholder="Enter Material Design Icon name"
                 style={errors.icon ? { border: '1px solid #ff4444', boxShadow: '0 0 5px rgba(255, 68, 68, 0.3)' } : {}}
-              />
+              >
+                <option value="">Select Material Design icon</option>
+                {!MATERIAL_DESIGN_ICON_VALUES.some((value) => value === iconInput) && iconInput && (
+                  <option value={iconInput}>{iconInput}</option>
+                )}
+                {MATERIAL_DESIGN_ICON_OPTIONS.map((iconOption) => (
+                  <option key={iconOption.value} value={iconOption.value}>
+                    {iconOption.label}
+                  </option>
+                ))}
+              </select>
               <span className={styles.iconPreview}>
                 <Icon icon={`mdi:${icon || 'help-circle'}`} />
               </span>

--- a/src/components/SubscriptionModal.tsx
+++ b/src/components/SubscriptionModal.tsx
@@ -10,10 +10,7 @@ import '@/styles/react-datepicker-dark.css';
 import { parseISO, startOfDay } from 'date-fns';
 import { Subscription } from '@/types';
 import { getRandomColor } from '@/lib/utils';
-import {
-  MATERIAL_DESIGN_ICON_OPTIONS,
-  MATERIAL_DESIGN_ICON_VALUES
-} from '@/constants/materialDesignIcons';
+import { MATERIAL_DESIGN_ICON_OPTIONS } from '@/constants/materialDesignIcons';
 import styles from './SubscriptionModal.module.css';
 
 const currencyList = require('currency-symbol-map/map');
@@ -134,7 +131,7 @@ export default function SubscriptionModal({
     onClose();
   };
 
-  const handleIconChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleIconChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIconInput(e.target.value);
     setIcon(e.target.value.toLowerCase());
   };
@@ -247,22 +244,22 @@ export default function SubscriptionModal({
           <div className={styles.formGroup}>
             <label htmlFor="icon">Icon <span style={{ color: '#ff4444' }}>*</span></label>
             <div className={styles.iconInputContainer}>
-              <select
+              <input
                 id="icon"
+                type="text"
+                list="icon-suggestions"
                 value={iconInput}
                 onChange={handleIconChange}
+                placeholder="Enter Material Design icon name"
                 style={errors.icon ? { border: '1px solid #ff4444', boxShadow: '0 0 5px rgba(255, 68, 68, 0.3)' } : {}}
-              >
-                <option value="">Select Material Design icon</option>
-                {!MATERIAL_DESIGN_ICON_VALUES.some((value) => value === iconInput) && iconInput && (
-                  <option value={iconInput}>{iconInput}</option>
-                )}
+              />
+              <datalist id="icon-suggestions">
                 {MATERIAL_DESIGN_ICON_OPTIONS.map((iconOption) => (
-                  <option key={iconOption.value} value={iconOption.value}>
+                  <option key={iconOption.value}>
                     {iconOption.label}
                   </option>
                 ))}
-              </select>
+              </datalist>
               <span className={styles.iconPreview}>
                 <Icon icon={`mdi:${icon || 'help-circle'}`} />
               </span>

--- a/src/constants/materialDesignIcons.ts
+++ b/src/constants/materialDesignIcons.ts
@@ -1,0 +1,45 @@
+export const MATERIAL_DESIGN_ICON_VALUES = [
+  'calendar',
+  'credit-card',
+  'cash',
+  'currency-usd',
+  'bank',
+  'cellphone',
+  'wifi',
+  'television',
+  'music',
+  'movie',
+  'gamepad',
+  'youtube',
+  'spotify',
+  'apple',
+  'microsoft',
+  'cloud',
+  'web',
+  'bell',
+  'cart',
+  'school',
+  'home',
+  'car',
+  'train',
+  'airplane',
+  'dumbbell',
+  'heart',
+  'shield',
+  'briefcase',
+  'help-circle'
+] as const;
+
+export type MaterialDesignIcon = typeof MATERIAL_DESIGN_ICON_VALUES[number];
+
+// help-circle -> Help Circle
+const formatIconLabel = (iconValue: string) =>
+  iconValue
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+export const MATERIAL_DESIGN_ICON_OPTIONS = MATERIAL_DESIGN_ICON_VALUES.map((value) => ({
+  value,
+  label: formatIconLabel(value)
+}));


### PR DESCRIPTION
I always thought its a bit inconvenient to have to go to material icon website to refer to the icon name and then input it by typing it into an input box.

i prefer a drop down select where user just select it. the list of icons is stored in /constant/materialDesignIcon. so that list can be extended if you want to add more options to it.

<img width="555" height="654" alt="image" src="https://github.com/user-attachments/assets/449cbd4a-a735-4662-81a2-ec8a33870b91" />

i would have preferred having a preview icon right beside the text in the drop down menu but this cant be done natively via html select, we need to use external library for that. maybe this can be considered in the future.
